### PR TITLE
flow : add layers path metric

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -53,6 +53,7 @@ type Flow struct {
 	Ipv4Src         string
 	Ipv4Dst         string
 	Protocol        string
+	Path            string
 	PortSrc         uint32
 	PortDst         uint32
 	Id              uint64
@@ -97,6 +98,16 @@ func (flow *Flow) fillFromGoPacket(packet *gopacket.Packet) error {
 		hasher.Write([]byte(flow.Ipv4Dst))
 		hasher.Write([]byte(flow.Protocol))
 	}
+
+	path := ""
+	for i, layer := range (*packet).Layers() {
+		if i > 0 {
+			path += "."
+		}
+		path += layer.LayerType().String()
+	}
+	flow.Path = path
+	hasher.Write([]byte(flow.Path))
 
 	udpLayer := (*packet).Layer(layers.LayerTypeUDP)
 	if udpLayer != nil {


### PR DESCRIPTION
Add layers path metric support, retreive layers path from the packet classifier.

Output example :
Ethernet.Dot1Q.IPv4.IGMP
Ethernet.IPv4.TCP
Ethernet.Dot1Q.IPv6.UDP.Payload
...