### PR TITLE
Fix link overwriting between netlink and ovs

### DIFF
--- a/topology/netlink_test.go
+++ b/topology/netlink_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/safchain/netlink"
+)
+
+type FakeOvsLink struct {
+	LinkAttrs netlink.LinkAttrs
+}
+
+func (l *FakeOvsLink) Type() string {
+	return "openvswitch"
+}
+
+func (l *FakeOvsLink) Attrs() *netlink.LinkAttrs {
+	return &l.LinkAttrs
+}
+
+func TestOvsLinkNotHandled(t *testing.T) {
+	topo := NewTopology()
+	root := topo.NewContainer("root", Root)
+
+	updater := NewNetLinkTopoUpdater(root)
+
+	link := &netlink.Device{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "intf1",
+		},
+	}
+	updater.addLinkToTopology(link)
+
+	if topo.GetInterface("intf1") == nil {
+		t.Error("interface of type device not found in the topology")
+	}
+
+	ovsLink := &FakeOvsLink{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "intf2",
+		},
+	}
+	updater.addLinkToTopology(ovsLink)
+
+	if topo.GetInterface("intf2") != nil {
+		t.Error("interface of type openvswitch should not have been added to the topology")
+	}
+
+}

--- a/topology/ovs.go
+++ b/topology/ovs.go
@@ -110,7 +110,7 @@ func (o *OvsTopoUpdater) OnOvsInterfaceAdd(monitor *ovsdb.OvsMonitor, uuid strin
 
 	switch row.New.Fields["mac_in_use"].(type) {
 	case string:
-		intf.Metadatas["mac"] = row.New.Fields["mac_in_use"].(string)
+		intf.Mac = row.New.Fields["mac_in_use"].(string)
 	}
 
 	/* set pending interface for a port */

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -38,9 +38,11 @@ const (
 
 type Interface struct {
 	sync.RWMutex
-	ID        string            `json:"-"`
-	Metadatas map[string]string `json:",omitempty	"`
-	port      *Port             `json:"-"`
+	ID        string `json:"-"`
+	Type      string
+	Mac       string
+	Metadatas map[string]string `json:",omitempty"`
+	Port      *Port             `json:"-"`
 }
 
 type Port struct {
@@ -93,7 +95,7 @@ func (topo *Topology) NewInterface(i string, p *Port) *Interface {
 
 	if p != nil {
 		p.Interfaces[i] = intf
-		intf.port = p
+		intf.Port = p
 		topo.Log()
 	}
 
@@ -109,8 +111,8 @@ func (topo *Topology) DelInterface(i string) {
 		return
 	}
 
-	if intf.port != nil {
-		delete(intf.port.Interfaces, i)
+	if intf.Port != nil {
+		delete(intf.Port.Interfaces, i)
 		topo.Log()
 	}
 
@@ -135,7 +137,11 @@ func (port *Port) AddInterface(intf *Interface) {
 	defer intf.Unlock()
 
 	port.Interfaces[intf.ID] = intf
-	intf.port = port
+	intf.Port = port
+
+	if port.container != nil && port.container.Topology != nil {
+		port.container.Topology.Log()
+	}
 }
 
 func (port *Port) GetContainer() *Container {
@@ -167,7 +173,7 @@ func (topo *Topology) DelPort(i string) {
 	}
 
 	for _, intf := range port.Interfaces {
-		intf.port = nil
+		intf.Port = nil
 	}
 
 	if port.container != nil {

--- a/topology/topology_test.go
+++ b/topology/topology_test.go
@@ -33,16 +33,16 @@ func TestSimpleTopology(t *testing.T) {
 	container1 := topo.NewContainer("C1", Root)
 	topo.NewPort("node-1", container1)
 	topo.NewPort("node-2", container1)
-	port := topo.NewPort("node-3", container1)
-	port.Metadatas["mac"] = "1.1.1.1.1.1"
+	topo.NewPort("node-3", container1)
 
 	container2 := topo.NewContainer("C2", NetNs)
 	topo.NewPort("node-4", container2)
 	port5 := topo.NewPort("node-5", container2)
-	topo.NewInterface("intf-1", port5)
+	intf := topo.NewInterface("intf-1", port5)
+	intf.Mac = "1.1.1.1.1.1"
 
-	expected := `{"Containers":{"C1":{"Type":"root","Ports":{"node-1":{},"node-2":{},"node-3":{"Metadatas":{"mac":"1.1.1.1.1.1"}}}},`
-	expected += `"C2":{"Type":"netns","Ports":{"node-4":{},"node-5":{"Interfaces":{"intf-1":{"Metadatas":{}}}}}}}}`
+	expected := `{"Containers":{"C1":{"Type":"root","Ports":{"node-1":{},"node-2":{},"node-3":{}}},`
+	expected += `"C2":{"Type":"netns","Ports":{"node-4":{},"node-5":{"Interfaces":{"intf-1":{"Type":"","Mac":"1.1.1.1.1.1"}}}}}}}`
 
 	j, _ := json.Marshal(topo)
 	if string(j) != expected {
@@ -56,16 +56,16 @@ func TestDeleteOperation(t *testing.T) {
 	container1 := topo.NewContainer("C1", Root)
 	topo.NewPort("node-1", container1)
 	topo.NewPort("node-2", container1)
-	port := topo.NewPort("node-3", container1)
-	port.Metadatas["mac"] = "1.1.1.1.1.1"
+	topo.NewPort("node-3", container1)
 
 	container2 := topo.NewContainer("C2", NetNs)
 	topo.NewPort("node-4", container2)
 	port5 := topo.NewPort("node-5", container2)
-	topo.NewInterface("intf-1", port5)
+	intf := topo.NewInterface("intf-1", port5)
+	intf.Mac = "1.1.1.1.1.1"
 
-	expected := `{"Containers":{"C1":{"Type":"root","Ports":{"node-1":{},"node-2":{},"node-3":{"Metadatas":{"mac":"1.1.1.1.1.1"}}}},`
-	expected += `"C2":{"Type":"netns","Ports":{"node-4":{},"node-5":{"Interfaces":{"intf-1":{"Metadatas":{}}}}}}}}`
+	expected := `{"Containers":{"C1":{"Type":"root","Ports":{"node-1":{},"node-2":{},"node-3":{}}},`
+	expected += `"C2":{"Type":"netns","Ports":{"node-4":{},"node-5":{"Interfaces":{"intf-1":{"Type":"","Mac":"1.1.1.1.1.1"}}}}}}}`
 
 	j, _ := json.Marshal(topo)
 	if string(j) != expected {
@@ -74,7 +74,7 @@ func TestDeleteOperation(t *testing.T) {
 
 	topo.DelContainer("C1")
 
-	expected = `{"Containers":{"C2":{"Type":"netns","Ports":{"node-4":{},"node-5":{"Interfaces":{"intf-1":{"Metadatas":{}}}}}}}}`
+	expected = `{"Containers":{"C2":{"Type":"netns","Ports":{"node-4":{},"node-5":{"Interfaces":{"intf-1":{"Type":"","Mac":"1.1.1.1.1.1"}}}}}}}`
 
 	j, _ = json.Marshal(topo)
 	if string(j) != expected {


### PR DESCRIPTION
Before this fix the netlink topo updater was erasing the
informations inserted by the ovs one.