### PR TITLE
[SFlow] Implement a more discret SFlow parser

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -142,6 +142,14 @@ func New(packet *gopacket.Packet, probePath *string) *Flow {
 	return flow
 }
 
+func FLowsFromGoPacket(packet gopacket.Packet, probePath *string) []*Flow {
+	flows := []*Flow{}
+
+	flow := New(&packet, probePath)
+	flows = append(flows, flow)
+	return flows
+}
+
 func FLowsFromSFlowSample(sample *layers.SFlowFlowSample, probePath *string) []*Flow {
 	flows := []*Flow{}
 


### PR DESCRIPTION
Aim to get more informations from SFlow metadata, by enhancing via SkydivePacket

SkydrivePacket (gopacket.Packet inheritance)
SFlowReader (gopacket.PacketSource inheritance):
  SFlowReader read packet from packetsource via a Skydive PacketChannel and inject it in related agents
  Packetsource inject Packets in gopacket parser, with collected/correlated metadate from SFlow library (github.com/Preetam/sflow)