### PR TITLE
New logger

### DIFF
--- a/cmd/pcap2sflow-replay/pcap2sflow-replay.go
+++ b/cmd/pcap2sflow-replay/pcap2sflow-replay.go
@@ -241,12 +241,6 @@ func usage() {
 }
 
 func main() {
-	err := logging.InitLogger()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-
 	pcaptrace := flag.String("trace", "", "PCAP trace file to read")
 	pps := flag.Uint("pps", 1000, "Packets per second")
 	PktsPerFlow := flag.Uint("pktspersflow", 5, "Number of Packets per SFlow Datagram")

--- a/cmd/pcap2sflow-replay/pcap2sflow-replay.go
+++ b/cmd/pcap2sflow-replay/pcap2sflow-replay.go
@@ -241,6 +241,12 @@ func usage() {
 }
 
 func main() {
+	err := logging.InitLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
 	pcaptrace := flag.String("trace", "", "PCAP trace file to read")
 	pps := flag.Uint("pps", 1000, "Packets per second")
 	PktsPerFlow := flag.Uint("pktspersflow", 5, "Number of Packets per SFlow Datagram")

--- a/cmd/skydive_agent/skydive_agent.go
+++ b/cmd/skydive_agent/skydive_agent.go
@@ -47,6 +47,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	err = logging.InitLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
 	fmt.Println("Skydive Agent starting...")
 	agent.NewAgent().Start()
 }

--- a/cmd/skydive_agent/skydive_agent.go
+++ b/cmd/skydive_agent/skydive_agent.go
@@ -48,12 +48,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = logging.InitLogger()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-
 	logging.GetLogger().Notice("Skydive Agent starting...")
 	agent.NewAgent().Start()
 }

--- a/cmd/skydive_agent/skydive_agent.go
+++ b/cmd/skydive_agent/skydive_agent.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/redhat-cip/skydive/agent"
 	"github.com/redhat-cip/skydive/config"
+	"github.com/redhat-cip/skydive/logging"
 )
 
 func usage() {
@@ -53,6 +54,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("Skydive Agent starting...")
+	logging.GetLogger().Notice("Skydive Agent starting...")
 	agent.NewAgent().Start()
 }

--- a/cmd/skydive_analyzer/skydive_analyzer.go
+++ b/cmd/skydive_analyzer/skydive_analyzer.go
@@ -70,6 +70,6 @@ func main() {
 	}
 	server.SetStorage(storage)
 
-	fmt.Println("Skydive Analyzer started !")
+	logging.GetLogger().Notice("Skydive Analyzer started !")
 	server.ListenAndServe()
 }

--- a/cmd/skydive_analyzer/skydive_analyzer.go
+++ b/cmd/skydive_analyzer/skydive_analyzer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/redhat-cip/skydive/analyzer"
 	"github.com/redhat-cip/skydive/config"
+	"github.com/redhat-cip/skydive/logging"
 	"github.com/redhat-cip/skydive/storage/elasticsearch"
 )
 
@@ -45,6 +46,12 @@ func main() {
 	flag.Parse()
 
 	err := config.InitConfigFromFile(*filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	err = logging.InitLogger()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/skydive_analyzer/skydive_analyzer.go
+++ b/cmd/skydive_analyzer/skydive_analyzer.go
@@ -51,12 +51,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = logging.InitLogger()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-
 	router := mux.NewRouter().StrictSlash(true)
 
 	server, err := analyzer.NewServerFromConfig(router)

--- a/etc/skydive.ini.default
+++ b/etc/skydive.ini.default
@@ -47,3 +47,8 @@ elasticsearch = 127.0.0.1:9200
 # graph backend memory, gremlin
 backend = memory
 gremlin = 127.0.0.1:8182
+
+[logging]
+default = INFO
+topology/probes = INFO
+topology/graph = WARNING

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -69,7 +69,7 @@ func initSkydiveLogger() {
 	skydiveLogger = SkydiveLogger{
 		id:      id,
 		loggers: make(map[string]*logging.Logger),
-		format:  "%{color}%{time} " + id + " %{shortfile} %{shortpkg} %{longfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}",
+		format:  "%{color}%{time} " + id + " %{shortfile} %{shortpkg} %{longfunc} > %{level:.4s} %{id:03x}%{color:reset} %{message}",
 	}
 	newLogger("default", "INFO")
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -24,6 +24,7 @@ package logging
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -128,7 +129,15 @@ func GetLogger() (log *logging.Logger) {
 	if !found {
 		log, found = skydiveLogger.loggers[pkg]
 		if !found {
-			log = skydiveLogger.loggers["default"]
+			log, found = skydiveLogger.loggers["default"]
+			if !found {
+				err := InitLogger()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+					os.Exit(1)
+				}
+				log, _ = skydiveLogger.loggers["default"]
+			}
 		}
 	}
 	return log

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -23,15 +23,113 @@
 package logging
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/op/go-logging"
+
+	"github.com/redhat-cip/skydive/config"
 )
 
-var log = logging.MustGetLogger("skydive")
-
-func InitLogger(name string) {
-	log = logging.MustGetLogger("log")
+func getPackageFunction() (pkg string, fun string) {
+	pkg, fun = "???", "???"
+	if pc, _, _, ok := runtime.Caller(2); ok {
+		if fr := runtime.FuncForPC(pc); fr != nil {
+			f := fr.Name()
+			i := strings.LastIndex(f, "/")
+			j := strings.Index(f[i+1:], ".")
+			if j < 1 {
+				return "???", "???"
+			}
+			pkg, fun = f[:i+j+1], f[i+j+2:]
+		}
+	}
+	return pkg, fun
 }
 
-func GetLogger() *logging.Logger {
+var skydiveLogger SkydiveLogger
+
+type SkydiveLogger struct {
+	loggers map[string]*logging.Logger
+	id      string
+	format  string
+	backend logging.Backend
+}
+
+func initSkydiveLogger() {
+	id, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+	id += "." + filepath.Base(os.Args[0])
+	skydiveLogger = SkydiveLogger{
+		id:      id,
+		loggers: make(map[string]*logging.Logger),
+		format:  "%{color}%{time} " + id + " %{shortfile} %{shortpkg} %{longfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}",
+	}
+	newLogger("default", "INFO")
+}
+
+func newLogger(pkg string, loglevel string) error {
+	level, err := logging.LogLevel(loglevel)
+	if err != nil {
+		return err
+	}
+	backend := logging.NewLogBackend(os.Stderr, "", 0)
+	backendFormat := logging.NewBackendFormatter(backend, logging.MustStringFormatter(skydiveLogger.format))
+	backendLevel := logging.AddModuleLevel(backendFormat)
+	backendLevel.SetLevel(level, pkg)
+
+	logger, err := logging.GetLogger(pkg)
+	if err != nil {
+		return err
+	}
+	logger.SetBackend(backendLevel)
+	skydiveLogger.loggers[pkg] = logger
+
+	skydiveLogger.loggers["default"].Debug("New Log Registered : " + pkg + " " + loglevel)
+	return nil
+}
+
+func InitLogger() error {
+	initSkydiveLogger()
+
+	cfg := config.GetConfig()
+	if cfg == nil {
+		return nil
+	}
+
+	sec, err := cfg.GetSection("logging")
+	if err != nil {
+		return nil
+	}
+
+	for cfgPkg, cfgLvl := range sec.KeysHash() {
+		pkg := strings.TrimSpace(cfgPkg)
+		lvl := strings.TrimSpace(cfgLvl)
+		if pkg == "default" {
+			err = newLogger("default", lvl)
+		} else {
+			err = newLogger("github.com/redhat-cip/skydive/"+pkg, lvl)
+		}
+		if err != nil {
+			return errors.New("Can't parse [logging] section line : \"" + pkg + " " + lvl + "\" " + err.Error())
+		}
+	}
+	return nil
+}
+
+func GetLogger() (log *logging.Logger) {
+	pkg, f := getPackageFunction()
+	log, found := skydiveLogger.loggers[pkg+"."+f]
+	if !found {
+		log, found = skydiveLogger.loggers[pkg]
+		if !found {
+			log = skydiveLogger.loggers["default"]
+		}
+	}
 	return log
 }


### PR DESCRIPTION
The newlogger read the configuration section [logging] to setup different
verbosity level. (default = INFO)
Valid level are : DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL

Configuration example:
[logging]
default = INFO
topology/probes = WARNING

Output example :

2016-02-02T23:37:08.538+11:00 quadnv.skydive_agent client.go:92 graph (*AsyncClient).connect > ERRO 007 Connection to the WebSocket server failed: dial tcp 127.0.0.1:8082: getsockopt: connection refused