### PR TITLE
Force driver to bridge when link type is bridge

### DIFF
--- a/topology/probes/netlink.go
+++ b/topology/probes/netlink.go
@@ -206,6 +206,9 @@ func (u *NetLinkProbe) addLinkToTopology(link netlink.Link) {
 	defer u.Graph.Unlock()
 
 	driver, _ := ethtool.DriverName(link.Attrs().Name)
+	if driver == "" && link.Type() == "bridge" {
+		driver = "bridge"
+	}
 
 	metadatas := graph.Metadatas{
 		"Name":    link.Attrs().Name,


### PR DESCRIPTION
The link can be added without the driver set first and then updated to a
bridge which leads to have twice the same node in the graph. With this
patch a bridge is always seen as a bridge.