### PR TITLE
Change log from Error to Warning when netlink doesn't find intf

### DIFF
--- a/topology/probes/netlink.go
+++ b/topology/probes/netlink.go
@@ -267,7 +267,7 @@ func (u *NetLinkProbe) addLinkToTopology(link netlink.Link) {
 func (u *NetLinkProbe) onLinkAdded(index int) {
 	link, err := netlink.LinkByIndex(index)
 	if err != nil {
-		logging.GetLogger().Error("Failed to find interface %d: %s", index, err.Error())
+		logging.GetLogger().Warning("Failed to find interface %d: %s", index, err.Error())
 		return
 	}
 


### PR DESCRIPTION
We can be notified that a interface is created while it has just be
removed, then it is impossible to find it.