### PR TITLE
Adapt log of SFlow packet parser, log as critical only non SFlow packets

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -135,11 +135,18 @@ func FLowsFromSFlowSample(ft *FlowTable, sample *layers.SFlowFlowSample, probePa
 	for _, rec := range sample.Records {
 
 		/* FIX(safchain): just keeping the raw packet for now */
-		record, ok := rec.(layers.SFlowRawPacketFlowRecord)
-		if !ok {
-			logging.GetLogger().Critical("1st layer is not SFlowRawPacketFlowRecord type")
+		switch rec.(type) {
+		case layers.SFlowRawPacketFlowRecord:
+			/* We only support RawPacket from SFlow probe */
+		case layers.SFlowExtendedSwitchFlowRecord:
+			logging.GetLogger().Debug("1st layer is not SFlowRawPacketFlowRecord type")
+			continue
+		default:
+			logging.GetLogger().Critical("1st layer is not a SFlow supported type")
 			continue
 		}
+
+		record := rec.(layers.SFlowRawPacketFlowRecord)
 
 		packet := &record.Header
 		key := (FlowKey{}).fillFromGoPacket(packet)


### PR DESCRIPTION
Before this patch even the SFLow packet that was not of type Raw were
logged as critical. But this kind of packet are legitimate we just
don't support them for the moment, log them in debug.