### PR TITLE
Append probepath for ES id so that we can follow flow

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -169,6 +169,17 @@ func (key FlowKey) String() string {
 	return fmt.Sprintf("%x-%x", key.net, key.transport)
 }
 
+func (flow *Flow) ID() string {
+	id := flow.UUID
+
+	// FIX(safchain) should not be empty, will be removed when having sync mapping
+	if flow.ProbeGraphPath != "" {
+		id += ":" + flow.ProbeGraphPath
+	}
+
+	return id
+}
+
 func (flow *Flow) fillFromGoPacket(packet *gopacket.Packet) error {
 	/* Continue if no ethernet layer */
 	ethernetLayer := (*packet).Layer(layers.LayerTypeEthernet)

--- a/storage/elasticsearch/elasticsearch.go
+++ b/storage/elasticsearch/elasticsearch.go
@@ -42,7 +42,7 @@ type ElasticSearchStorage struct {
 
 func (c *ElasticSearchStorage) StoreFlows(flows []*flow.Flow) error {
 	for _, flow := range flows {
-		err := c.indexer.Index("skydive", "flow", flow.UUID, "", "", nil, flow)
+		err := c.indexer.Index("skydive", "flow", flow.ID(), "", "", nil, flow)
 		if err != nil {
 			logging.GetLogger().Error("Error while indexing: %s", err.Error())
 			continue


### PR DESCRIPTION
Appending the probepath to the id of ES we will have multiple entries
for the same flow depending where the packet has been captured so that
we can follow packets from point to point.